### PR TITLE
refactor: centralize UI helpers

### DIFF
--- a/Editor/Core.Editor/Hub/DevkitTheme.cs
+++ b/Editor/Core.Editor/Hub/DevkitTheme.cs
@@ -30,6 +30,16 @@ namespace Pitech.XR.Core.Editor
             return ve;
         }
 
+        public static VisualElement Section(string title, System.Action<VisualElement> fill)
+        {
+            var ve = Section(title);
+            var content = new VisualElement();
+            content.style.flexDirection = FlexDirection.Column;
+            ve.Add(content);
+            fill?.Invoke(content);
+            return ve;
+        }
+
         public static Label Body(string text, bool dim=false)
             => new(text) { style = { color = dim ? SubText : Text, fontSize = 12 } };
 
@@ -54,6 +64,45 @@ namespace Pitech.XR.Core.Editor
             b.style.borderTopLeftRadius = b.style.borderTopRightRadius =
             b.style.borderBottomLeftRadius = b.style.borderBottomRightRadius = 6;
             return b;
+        }
+
+        public static Button Button(string text, System.Action onClick, System.Action<Button>? customize = null)
+        {
+            var b = new Button(onClick) { text = text };
+            customize?.Invoke(b);
+            return b;
+        }
+
+        public static Button WideButton(string text, System.Action onClick, System.Action<Button>? customize = null)
+        {
+            var b = Button(text, onClick);
+            b.style.width = Length.Percent(100);
+            b.style.marginBottom = 8;
+            customize?.Invoke(b);
+            return b;
+        }
+
+        public static VisualElement Badge(bool ok, string label, System.Action<VisualElement>? customize = null)
+        {
+            var row = Row();
+            var dot = new VisualElement
+            {
+                style =
+                {
+                    width = 10,
+                    height = 10,
+                    borderTopLeftRadius = 5,
+                    borderBottomLeftRadius = 5,
+                    borderTopRightRadius = 5,
+                    borderBottomRightRadius = 5,
+                    backgroundColor = ok ? new Color(0.3f, 0.9f, 0.5f) : new Color(0.95f, 0.35f, 0.35f),
+                    marginRight = 6
+                }
+            };
+            row.Add(dot);
+            row.Add(new Label(label) { style = { color = Text } });
+            customize?.Invoke(row);
+            return row;
         }
 
         public static VisualElement Divider()

--- a/Editor/Core.Editor/Pages/AboutPage.cs
+++ b/Editor/Core.Editor/Pages/AboutPage.cs
@@ -10,7 +10,7 @@ namespace Pitech.XR.Core.Editor
 
         public void BuildUI(VisualElement root)
         {
-            root.Add(Section("Pi tech XR DevKit", el =>
+            root.Add(DevkitTheme.Section("Pi tech XR DevKit", el =>
             {
                 if (DevkitContext.SidebarLogo != null)
                 {
@@ -21,28 +21,8 @@ namespace Pitech.XR.Core.Editor
                     el.Add(img);
                 }
                 el.Add(new Label($"Version: {DevkitContext.Version}"));
-                el.Add(new Label("© Pi tech"));
+                el.Add(new Label(" Pi tech"));
             }));
-        }
-
-        static VisualElement Section(string title, System.Action<VisualElement> fill)
-        {
-            var box = new VisualElement
-            {
-                style =
-                {
-                    backgroundColor = new Color(0.13f, 0.15f, 0.18f, 1f),
-                    paddingTop = 10, paddingBottom = 10, paddingLeft = 10, paddingRight = 10,
-                    marginBottom = 10, borderTopLeftRadius = 6, borderTopRightRadius = 6,
-                    borderBottomLeftRadius = 6, borderBottomRightRadius = 6
-                }
-            };
-            var label = new Label(title) { style = { unityFontStyleAndWeight = FontStyle.Bold, marginBottom = 6 } };
-            box.Add(label);
-            var content = new VisualElement();
-            box.Add(content);
-            fill?.Invoke(content);
-            return box;
         }
     }
 }

--- a/Editor/Core.Editor/Pages/DashboardPage.cs
+++ b/Editor/Core.Editor/Pages/DashboardPage.cs
@@ -11,12 +11,12 @@ namespace Pitech.XR.Core.Editor
 
         public void BuildUI(VisualElement root)
         {
-            root.Add(Section("Project Setup", el =>
+            root.Add(DevkitTheme.Section("Project Setup", el =>
             {
-                el.Add(Badge(DevkitContext.HasTimeline, "Unity Timeline"));
-                el.Add(Badge(DevkitContext.HasTextMeshPro, "TextMeshPro"));
-                el.Add(Badge(false, "Scenario module"));
-                el.Add(Badge(false, "Stats module"));
+                el.Add(DevkitTheme.Badge(DevkitContext.HasTimeline, "Unity Timeline"));
+                el.Add(DevkitTheme.Badge(DevkitContext.HasTextMeshPro, "TextMeshPro"));
+                el.Add(DevkitTheme.Badge(false, "Scenario module"));
+                el.Add(DevkitTheme.Badge(false, "Stats module"));
 
                 var hint = new HelpBox(
                     "Enable modules you need, then use the actions below to create assets & scene objects.",
@@ -24,84 +24,25 @@ namespace Pitech.XR.Core.Editor
                 hint.style.marginTop = 6; el.Add(hint);
             }));
 
-            root.Add(Section("Quick Actions", el =>
+            root.Add(DevkitTheme.Section("Quick Actions", el =>
             {
-                el.Add(WideButton("Create StatsConfig asset", CreateStatsConfigAsset));
+                el.Add(DevkitTheme.WideButton("Create StatsConfig asset", CreateStatsConfigAsset));
                 var row = new VisualElement { style = { flexDirection = FlexDirection.Row } };
-                row.Add(Button("Create Scenario GameObject", CreateScenarioGO));
+                row.Add(DevkitTheme.Button("Create Scenario GameObject", CreateScenarioGO, b => b.style.marginRight = 8));
                 row.Add(new Label("  Scenario Graph available") { style = { color = new Color(0.4f, 1f, 0.5f) } });
                 row.Add(new VisualElement { style = { flexGrow = 1 } });
-                row.Add(Button("Open Scenario Graph", OpenScenarioGraph));
+                row.Add(DevkitTheme.Button("Open Scenario Graph", OpenScenarioGraph));
                 el.Add(row);
             }));
 
-            root.Add(Section("Utilities", el =>
+            root.Add(DevkitTheme.Section("Utilities", el =>
             {
                 var row = new VisualElement { style = { flexDirection = FlexDirection.Row } };
-                row.Add(Button("Open Package Manager", () => EditorApplication.ExecuteMenuItem("Window/Package Manager")));
-                row.Add(Button("Reimport All", () => AssetDatabase.ImportAsset("Assets", ImportAssetOptions.ForceUpdate)));
+                row.Add(DevkitTheme.Button("Open Package Manager", () => EditorApplication.ExecuteMenuItem("Window/Package Manager"), b => b.style.marginRight = 8));
+                row.Add(DevkitTheme.Button("Reimport All", () => AssetDatabase.ImportAsset("Assets", ImportAssetOptions.ForceUpdate)));
                 el.Add(row);
             }));
         }
-
-        // ---------- helpers ----------
-        static VisualElement Section(string title, System.Action<VisualElement> fill)
-        {
-            var box = new VisualElement
-            {
-                style =
-                {
-                    backgroundColor = new Color(0.13f, 0.15f, 0.18f, 1f),
-                    paddingTop = 10, paddingBottom = 10, paddingLeft = 10, paddingRight = 10,
-                    marginBottom = 10, borderTopLeftRadius = 6, borderTopRightRadius = 6,
-                    borderBottomLeftRadius = 6, borderBottomRightRadius = 6
-                }
-            };
-            var label = new Label(title);
-            label.style.unityFontStyleAndWeight = FontStyle.Bold;
-            label.style.marginBottom = 6;
-            box.Add(label);
-
-            var content = new VisualElement();
-            content.style.flexDirection = FlexDirection.Column;
-            box.Add(content);
-            fill?.Invoke(content);
-            return box;
-        }
-
-        static Button Button(string text, System.Action onClick)
-        {
-            var b = new Button(onClick) { text = text };
-            b.style.marginRight = 8;
-            return b;
-        }
-
-        static VisualElement WideButton(string text, System.Action onClick)
-        {
-            var b = new Button(onClick) { text = text };
-            b.style.width = Length.Percent(100);
-            b.style.marginBottom = 8;
-            return b;
-        }
-
-        static VisualElement Badge(bool ok, string label)
-        {
-            var row = new VisualElement { style = { flexDirection = FlexDirection.Row, alignItems = Align.Center } };
-            var dot = new VisualElement
-            {
-                style =
-                {
-                    width = 10, height = 10, borderTopLeftRadius = 5, borderBottomLeftRadius = 5,
-                    borderTopRightRadius = 5, borderBottomRightRadius = 5,
-                    backgroundColor = ok ? new Color(0.3f, 0.9f, 0.5f) : new Color(0.95f, 0.35f, 0.35f),
-                    marginRight = 6
-                }
-            };
-            row.Add(dot);
-            row.Add(new Label(label));
-            return row;
-        }
-
         // Actions (replace with your implementations)
         static void CreateStatsConfigAsset()
         {

--- a/Editor/Core.Editor/Pages/ModulesPage.cs
+++ b/Editor/Core.Editor/Pages/ModulesPage.cs
@@ -11,47 +11,25 @@ namespace Pitech.XR.Core.Editor
 
         public void BuildUI(VisualElement root)
         {
-            root.Add(Section("Scenario", el =>
+            root.Add(DevkitTheme.Section("Scenario", el =>
             {
                 el.Add(new Label("Node-based flow of steps (Timeline → Cue Cards → Questions)."));
                 var row = new VisualElement { style = { flexDirection = FlexDirection.Row } };
                 row.Add(new Label("Enabled")); row.Add(new VisualElement { style = { width = 8 } });
-                row.Add(Button("Open", () => EditorApplication.ExecuteMenuItem("Window/General/Inspector")));
+                row.Add(DevkitTheme.Button("Open", () => EditorApplication.ExecuteMenuItem("Window/General/Inspector")));
                 el.Add(row);
             }));
 
-            root.Add(Section("Stats", el =>
+            root.Add(DevkitTheme.Section("Stats", el =>
             {
                 el.Add(new Label("Configurable KPI system with runtime values and optional UI bindings."));
                 var row = new VisualElement { style = { flexDirection = FlexDirection.Row } };
                 row.Add(new Label("Enabled")); row.Add(new VisualElement { style = { width = 8 } });
-                row.Add(Button("Open", () => EditorApplication.ExecuteMenuItem("Window/General/Project Settings")));
+                row.Add(DevkitTheme.Button("Open", () => EditorApplication.ExecuteMenuItem("Window/General/Project Settings")));
                 el.Add(row);
             }));
         }
 
-        // Helpers
-        static VisualElement Section(string title, System.Action<VisualElement> fill)
-        {
-            var box = new VisualElement
-            {
-                style =
-                {
-                    backgroundColor = new Color(0.13f, 0.15f, 0.18f, 1f),
-                    paddingTop = 10, paddingBottom = 10, paddingLeft = 10, paddingRight = 10,
-                    marginBottom = 10, borderTopLeftRadius = 6, borderTopRightRadius = 6,
-                    borderBottomLeftRadius = 6, borderBottomRightRadius = 6
-                }
-            };
-            var label = new Label(title) { style = { unityFontStyleAndWeight = FontStyle.Bold, marginBottom = 6 } };
-            box.Add(label);
-            var content = new VisualElement();
-            box.Add(content);
-            fill?.Invoke(content);
-            return box;
-        }
-
-        static Button Button(string text, System.Action onClick) => new Button(onClick) { text = text };
     }
 }
 #endif

--- a/Editor/Core.Editor/Pages/SettingsPage.cs
+++ b/Editor/Core.Editor/Pages/SettingsPage.cs
@@ -11,40 +11,18 @@ namespace Pitech.XR.Core.Editor
 
         public void BuildUI(VisualElement root)
         {
-            root.Add(Section("DevKit", el =>
+            root.Add(DevkitTheme.Section("DevKit", el =>
             {
                 el.Add(new Label($"Version: {DevkitContext.Version}"));
                 el.Add(new Label($"Timeline present: {DevkitContext.HasTimeline}"));
                 el.Add(new Label($"TextMeshPro present: {DevkitContext.HasTextMeshPro}"));
             }));
 
-            root.Add(Section("Project Settings", el =>
+            root.Add(DevkitTheme.Section("Project Settings", el =>
             {
-                el.Add(Button("Open Project Settings", () => SettingsService.OpenProjectSettings("Project")));
+                el.Add(DevkitTheme.Button("Open Project Settings", () => SettingsService.OpenProjectSettings("Project")));
             }));
         }
-
-        static VisualElement Section(string title, System.Action<VisualElement> fill)
-        {
-            var box = new VisualElement
-            {
-                style =
-                {
-                    backgroundColor = new Color(0.13f, 0.15f, 0.18f, 1f),
-                    paddingTop = 10, paddingBottom = 10, paddingLeft = 10, paddingRight = 10,
-                    marginBottom = 10, borderTopLeftRadius = 6, borderTopRightRadius = 6,
-                    borderBottomLeftRadius = 6, borderBottomRightRadius = 6
-                }
-            };
-            var label = new Label(title) { style = { unityFontStyleAndWeight = FontStyle.Bold, marginBottom = 6 } };
-            box.Add(label);
-            var content = new VisualElement();
-            box.Add(content);
-            fill?.Invoke(content);
-            return box;
-        }
-
-        static Button Button(string text, System.Action onClick) => new Button(onClick) { text = text };
     }
 }
 #endif

--- a/Editor/Core.Editor/Pages/ToolsPage.cs
+++ b/Editor/Core.Editor/Pages/ToolsPage.cs
@@ -10,31 +10,12 @@ namespace Pitech.XR.Core.Editor
 
         public void BuildUI(VisualElement root)
         {
-            root.Add(Section("Utilities", el =>
+            root.Add(DevkitTheme.Section("Utilities", el =>
             {
                 el.Add(new Label("Project scaffolding, addressables helpers, prefabs, etc. (coming soon)."));
             }));
         }
 
-        static VisualElement Section(string title, System.Action<VisualElement> fill)
-        {
-            var box = new VisualElement
-            {
-                style =
-                {
-                    backgroundColor = new Color(0.13f, 0.15f, 0.18f, 1f),
-                    paddingTop = 10, paddingBottom = 10, paddingLeft = 10, paddingRight = 10,
-                    marginBottom = 10, borderTopLeftRadius = 6, borderTopRightRadius = 6,
-                    borderBottomLeftRadius = 6, borderBottomRightRadius = 6
-                }
-            };
-            var label = new Label(title) { style = { unityFontStyleAndWeight = FontStyle.Bold, marginBottom = 6 } };
-            box.Add(label);
-            var content = new VisualElement();
-            box.Add(content);
-            fill?.Invoke(content);
-            return box;
-        }
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- move common Section, Button, WideButton, and Badge helpers into DevkitTheme
- refactor editor pages to use shared helpers for consistent styling

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68c1e3ac7e908329abaf91ddc1c91ee3